### PR TITLE
[Bugfix] Remove draft page creation from setup.

### DIFF
--- a/src/components/match-message.ts
+++ b/src/components/match-message.ts
@@ -54,7 +54,6 @@ export const LobbyDetailsEmbed = (
   scrimID: number,
   teammates: User[],
   enemies: User[],
-  draftURL: string,
   lobbyName: string,
   password: number,
   scoutingLinkTeam: string,
@@ -63,8 +62,6 @@ export const LobbyDetailsEmbed = (
   const detailsText = `
       Lobby name: ${lobbyName}
       Password: ${password}
-      [**Become Draft Captain**](${draftURL})
-      [**Spectate draft**](${draftURL.split('/').slice(0, -1).join('/')})
       `;
   const scoutingLinksMsg = `
     [**Team Profiles**](${scoutingLinkTeam})

--- a/src/services/matchdetail-service.ts
+++ b/src/services/matchdetail-service.ts
@@ -26,10 +26,11 @@ export class MatchDetailServiceImpl implements MatchDetailService {
     players: Player[],
     lobbyDetails: LobbyDetails
   ): Promise<void> {
+    // # T123456: re-add changes to add lobby draft details in the bot messages
+    // this.createDraftLobby(lobbyDetails.teamNames),
     const { BLUE, RED } = this.sortUsersByTeam(users, players);
-    const [voiceChannels, draftLobby, blueScoutingLink, redScoutingLink] = await Promise.all([
+    const [voiceChannels, blueScoutingLink, redScoutingLink] = await Promise.all([
       this.discordService.createVoiceChannels(scrim, BLUE, RED),
-      this.createDraftLobby(lobbyDetails.teamNames),
       this.generateScoutingLink(BLUE, scrim.region),
       this.generateScoutingLink(RED, scrim.region)
     ]);
@@ -41,7 +42,6 @@ export class MatchDetailServiceImpl implements MatchDetailService {
       scrim.id,
       BLUE,
       RED,
-      draftLobby.BLUE,
       `ss${scrim.id}`,
       password,
       blueScoutingLink,
@@ -52,12 +52,10 @@ export class MatchDetailServiceImpl implements MatchDetailService {
       scrim.id,
       RED,
       BLUE,
-      draftLobby.RED,
       `ss${scrim.id}`,
       password,
       redScoutingLink,
       blueScoutingLink
-      
     );
 
     // We have some test users that we don't want to send DMs to
@@ -72,7 +70,8 @@ export class MatchDetailServiceImpl implements MatchDetailService {
       this.discordService.sendMatchDirectMessage(redIDs, {
         embeds: [matchEmbed, redEmbed]
       }),
-      this.prisma.draft.create({ data: { scrimId: scrim.id, draftRoomId: draftLobby.roomId } })
+      // # T123456: draftRoomId: draftLobby.roomId
+      this.prisma.draft.create({ data: { scrimId: scrim.id, draftRoomId: scrim.id.toString() } })
     ]);
     console.log(`${dm1 + dm2} DMs have been sent`);
 
@@ -84,7 +83,8 @@ export class MatchDetailServiceImpl implements MatchDetailService {
             content: `Invite for ${vc.name}: ${invite}`
           });
         })
-      ),
+      )
+      /* # T123456: re-enable channel message once drafting works
       this.discordService.sendMessageInChannel({
         embeds: [
           matchEmbed.addFields({
@@ -93,6 +93,7 @@ export class MatchDetailServiceImpl implements MatchDetailService {
           })
         ]
       })
+      */
     ]);
   }
 

--- a/src/services/scrim-service.ts
+++ b/src/services/scrim-service.ts
@@ -125,9 +125,11 @@ export const initScrimService = (prisma: PrismaClient, matchmakingService: Match
       const draft = await prisma.draft.findUnique({
         where: { scrimId: scrim.id }
       });
+      /* # T123456: re-enable storing draft once drafting works. in current state is a no-op
       if (draft) {
         await matchDetailService.storeDraft(scrim.id, draft.draftRoomId);
       }
+      */
       console.info(text);
       return res.length > 0;
     },


### PR DESCRIPTION
Was mentioned earlier that draft page creation might be the source of errors for messages not sending out to users. Unable to test on my end without setting up a separate discord server whether this fully integrates correctly. However if drafting page is the issue this should serve as a quick fix?

- Draft page creation is simple enough to do manually.
- There's a section of code which stores drafts, but as far as I understand that code isn't functioning?